### PR TITLE
Correct the singular and plural usage for kelvins

### DIFF
--- a/lib/definitions/temperature.js
+++ b/lib/definitions/temperature.js
@@ -12,8 +12,8 @@ metric = {
   },
   K: {
     name: {
-      singular: 'degree Kelvin'
-    , plural: 'degrees Kelvin'
+      singular: 'Kelvin'
+    , plural: 'Kelvins'
     }
   , to_anchor: 1
   , anchor_shift: 273.15


### PR DESCRIPTION
Following up on the fix for https://exosite.atlassian.net/browse/EXOSENSE-6796
The correct usage for the unit is "Kelvin" not "degree Kelvin" https://www.nist.gov/si-redefinition/kelvin-introduction